### PR TITLE
Add `presented.isBeingDismissed` check for the dismiss logic

### DIFF
--- a/RouteComposer/Classes/Router/DefaultRouter.swift
+++ b/RouteComposer/Classes/Router/DefaultRouter.swift
@@ -237,7 +237,9 @@ public struct DefaultRouter: Router, InterceptableRouter, MainThreadChecking {
 
     // Dismisses all the view controllers presented if there are any
     private func dismissPresentedIfNeeded(from viewController: UIViewController, animated: Bool, completion: @escaping (() -> Void)) {
-        if viewController.presentedViewController != nil {
+      self.logger?.log(.info("Trying to dismiss \(String(describing: viewController.presentedViewController))"
+        + " while it isBeingDismissed: \(String(describing: viewController.presentedViewController?.isBeingDismissed))"))
+        if let presentedController = viewController.presentedViewController, !presentedController.isBeingDismissed {
             viewController.dismiss(animated: animated) {
                 self.logger?.log(.info("Dismissed all the view controllers presented from \(String(describing: viewController))"))
                 completion()


### PR DESCRIPTION
I faced an issue when routing silently fails with no log messages or throwing errors.
The reason was in calling 
```swift
func dismiss(animated flag: Bool, completion: (() -> Void)? = nil)
```
on a view controller wchich has `presentedViewController` but this `presentedViewController `  is already been dismissed by some other code (FacebookSDK hides SFSafariViewController in my case) (i.e `isBeingDismissed == true`). In a such case `completion` is not called and as a result routing stops.
To fix the issue `isBeingDismissed ` check was added to `dismissPresentedIfNeeded`. Also added extra log message for this case.