### PR TITLE
Add a push-on-to action for split view controller, where the detail i…

### DIFF
--- a/Example/Tests/ActionTests.swift
+++ b/Example/Tests/ActionTests.swift
@@ -377,7 +377,58 @@ class ActionTests: XCTestCase {
         XCTAssertEqual(splitController.viewControllers.count, 2)
         XCTAssertTrue(splitController.viewControllers.last === viewController)
     }
+  
+    func testPushOnToDetailsInSplit() {
+        var viewControllerStack: [UIViewController] = []
+        XCTAssertThrowsError(try UISplitViewController.pushOnToDetails().perform(embedding: UIViewController(), in: &viewControllerStack))
 
+        viewControllerStack.append(UIViewController())
+      
+        try? UISplitViewController.pushOnToDetails().perform(embedding: UIViewController(), in: &viewControllerStack)
+        XCTAssertEqual(viewControllerStack.count, 2)
+
+        let lastViewController = UIViewController()
+        try? UISplitViewController.pushOnToDetails().perform(embedding: lastViewController, in: &viewControllerStack)
+        XCTAssertEqual(viewControllerStack.count, 3)
+        XCTAssertEqual(viewControllerStack.last, lastViewController)
+
+        var wasInCompletion = false
+        let splitController = UISplitViewController()
+        var viewController = UIViewController()
+        UISplitViewController.pushOnToDetails().perform(with: viewController, on: splitController, animated: false) { result in
+            wasInCompletion = true
+            if case .success = result {
+                XCTAssert(false)
+            }
+        }
+        XCTAssertTrue(wasInCompletion)
+        XCTAssertEqual(splitController.viewControllers.count, 0)
+    
+        wasInCompletion = false
+        let navController: UINavigationController = UINavigationController()
+        splitController.viewControllers = [UIViewController(), navController]
+        UISplitViewController.pushOnToDetails().perform(with: viewController, on: splitController, animated: false) { result in
+            wasInCompletion = true
+            if case .failure(_) = result {
+                XCTAssert(false)
+            }
+        }
+        XCTAssertTrue(wasInCompletion)
+        XCTAssertEqual(navController.viewControllers.count, 1)
+        XCTAssertTrue(navController.viewControllers.last === viewController)
+      
+        viewController = UIViewController()
+        UISplitViewController.pushOnToDetails().perform(with: viewController, on: splitController, animated: false) { result in
+          wasInCompletion = true
+          if case .failure(_) = result {
+            XCTAssert(false)
+          }
+        }
+        XCTAssertTrue(wasInCompletion)
+        XCTAssertEqual(navController.viewControllers.count, 2)
+        XCTAssertTrue(navController.viewControllers.last === viewController)
+     }
+    
     func testCustomWindowProvider() {
         let window = UIWindow()
         let customProvider = CustomWindowProvider(window: window)

--- a/Example/Tests/ActionTests.swift
+++ b/Example/Tests/ActionTests.swift
@@ -377,13 +377,13 @@ class ActionTests: XCTestCase {
         XCTAssertEqual(splitController.viewControllers.count, 2)
         XCTAssertTrue(splitController.viewControllers.last === viewController)
     }
-  
+
     func testPushOnToDetailsInSplit() {
         var viewControllerStack: [UIViewController] = []
         XCTAssertThrowsError(try UISplitViewController.pushOnToDetails().perform(embedding: UIViewController(), in: &viewControllerStack))
 
         viewControllerStack.append(UIViewController())
-      
+
         try? UISplitViewController.pushOnToDetails().perform(embedding: UIViewController(), in: &viewControllerStack)
         XCTAssertEqual(viewControllerStack.count, 2)
 
@@ -403,7 +403,7 @@ class ActionTests: XCTestCase {
         }
         XCTAssertTrue(wasInCompletion)
         XCTAssertEqual(splitController.viewControllers.count, 0)
-    
+
         wasInCompletion = false
         let navController: UINavigationController = UINavigationController()
         splitController.viewControllers = [UIViewController(), navController]
@@ -416,7 +416,7 @@ class ActionTests: XCTestCase {
         XCTAssertTrue(wasInCompletion)
         XCTAssertEqual(navController.viewControllers.count, 1)
         XCTAssertTrue(navController.viewControllers.last === viewController)
-      
+
         viewController = UIViewController()
         UISplitViewController.pushOnToDetails().perform(with: viewController, on: splitController, animated: false) { result in
           wasInCompletion = true
@@ -427,8 +427,8 @@ class ActionTests: XCTestCase {
         XCTAssertTrue(wasInCompletion)
         XCTAssertEqual(navController.viewControllers.count, 2)
         XCTAssertTrue(navController.viewControllers.last === viewController)
-     }
-    
+    }
+
     func testCustomWindowProvider() {
         let window = UIWindow()
         let customProvider = CustomWindowProvider(window: window)
@@ -436,3 +436,4 @@ class ActionTests: XCTestCase {
     }
 
 }
+

--- a/Example/Tests/ActionTests.swift
+++ b/Example/Tests/ActionTests.swift
@@ -434,6 +434,4 @@ class ActionTests: XCTestCase {
         let customProvider = CustomWindowProvider(window: window)
         XCTAssertEqual(window, customProvider.window)
     }
-
 }
-

--- a/RouteComposer/Classes/Actions/UISplitViewController+Action.swift
+++ b/RouteComposer/Classes/Actions/UISplitViewController+Action.swift
@@ -86,14 +86,14 @@ public struct SplitViewControllerActions {
             completion(.success)
         }
     }
-  
+
     /// Pushes a view controller *onto* the detail stack in the `UISplitViewController`, where the detail is a `UINavigationController`
     public struct PushOnToDetailsAction<ViewController: UISplitViewController>: ContainerAction {
-      
+
       /// Constructor
       init() {
       }
-      
+
       public func perform(embedding viewController: UIViewController, in childViewControllers: inout [UIViewController]) throws {
         guard !childViewControllers.isEmpty else {
           throw RoutingError.compositionFailed(.init("Master view controller is not set in " +
@@ -101,7 +101,7 @@ public struct SplitViewControllerActions {
         }
         childViewControllers.append(viewController)
       }
-      
+
       public func perform(with viewController: UIViewController,
                           on splitViewController: ViewController,
                           animated: Bool,
@@ -111,16 +111,17 @@ public struct SplitViewControllerActions {
             "\(splitViewController) to push on a detail view controller \(viewController)."))))
           return
         }
-        
+
         guard let navController = (splitViewController.viewControllers.last as? UINavigationController) else {
           completion(.failure(RoutingError.compositionFailed(.init("Detail navigation controller is not set in " +
             "\(splitViewController) to push on a detail view controller \(viewController)."))))
           return
         }
-        
+
         navController.pushViewController(viewController, animated: animated)
         completion(.success)
       }
     }
-    
+
 }
+

--- a/RouteComposer/Classes/Actions/UISplitViewController+Action.swift
+++ b/RouteComposer/Classes/Actions/UISplitViewController+Action.swift
@@ -122,6 +122,4 @@ public struct SplitViewControllerActions {
         completion(.success)
       }
     }
-
 }
-

--- a/RouteComposer/Classes/Actions/UISplitViewController+Action.swift
+++ b/RouteComposer/Classes/Actions/UISplitViewController+Action.swift
@@ -14,11 +14,15 @@ public extension ContainerViewController where Self: UISplitViewController {
         return SplitViewControllerActions.SetAsMasterAction()
     }
 
-    /// Presents a view controller as a detail in the `UISplitViewController`
+    /// Presents a view controller as a detail in the `UISplitViewController`, *replacing* the previous detail.
     static func pushToDetails() -> SplitViewControllerActions.PushToDetailsAction<Self> {
         return SplitViewControllerActions.PushToDetailsAction()
     }
 
+    /// Pushes a view controller *onto* the detail stack in the `UISplitViewController`
+    static func pushOnToDetails() -> RouteComposer.SplitViewControllerActions.PushOnToDetailsAction<Self> {
+      return SplitViewControllerActions.PushOnToDetailsAction()
+    }
 }
 
 /// Actions for `UISplitViewController`
@@ -53,7 +57,7 @@ public struct SplitViewControllerActions {
 
     }
 
-    /// Presents a detail view controller in the `UISplitViewController`
+    /// Presents a detail view controller in the `UISplitViewController`, *replacing* the previous detail.
     public struct PushToDetailsAction<ViewController: UISplitViewController>: ContainerAction {
 
         /// Constructor
@@ -82,5 +86,41 @@ public struct SplitViewControllerActions {
             completion(.success)
         }
     }
-
+  
+    /// Pushes a view controller *onto* the detail stack in the `UISplitViewController`, where the detail is a `UINavigationController`
+    public struct PushOnToDetailsAction<ViewController: UISplitViewController>: ContainerAction {
+      
+      /// Constructor
+      init() {
+      }
+      
+      public func perform(embedding viewController: UIViewController, in childViewControllers: inout [UIViewController]) throws {
+        guard !childViewControllers.isEmpty else {
+          throw RoutingError.compositionFailed(.init("Master view controller is not set in " +
+            "UISplitViewController to push on a detail view controller \(viewController)."))
+        }
+        childViewControllers.append(viewController)
+      }
+      
+      public func perform(with viewController: UIViewController,
+                          on splitViewController: ViewController,
+                          animated: Bool,
+                          completion: @escaping (_: RoutingResult) -> Void) {
+        guard !splitViewController.viewControllers.isEmpty else {
+          completion(.failure(RoutingError.compositionFailed(.init("Master view controller is not set in " +
+            "\(splitViewController) to push on a detail view controller \(viewController)."))))
+          return
+        }
+        
+        guard let navController = (splitViewController.viewControllers.last as? UINavigationController) else {
+          completion(.failure(RoutingError.compositionFailed(.init("Detail navigation controller is not set in " +
+            "\(splitViewController) to push on a detail view controller \(viewController)."))))
+          return
+        }
+        
+        navController.pushViewController(viewController, animated: animated)
+        completion(.success)
+      }
+    }
+    
 }


### PR DESCRIPTION
Adds a split view action to push on a new view controller to the split view's detail stack. I wasn't sure if it would be appropriate to create a navigation controller for the detail if missing within the action, so routing will fail if the navigation controller isn't there.